### PR TITLE
chore(ci): remove pre-commit cache restore key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,8 +232,6 @@ jobs:
           path: |
             ${{ env.PRE_COMMIT_HOME }}
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Pre-commit does not clean up any files, resulting in the cache bloating indefinitely if the cache is restored from a previous key. With this change, the pre-commit cache is cleared whenever the pre-commit config is updated.